### PR TITLE
dont error if client files are missing

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -22,7 +22,6 @@ const (
 	tickTime       = 1.0 / ticksPerSecond
 
 	messagePerTickLimit = 60
-	maximumMessageSize  = 1024 * 1024 //1MB
 )
 
 func main() {
@@ -49,7 +48,7 @@ func serveClient(port int, errc chan error) error {
 	for client := range clientChecksums {
 		f, err := os.Open(client)
 		if err != nil {
-			return err
+			continue
 		}
 		h := md5.New()
 		if _, err := io.Copy(h, f); err != nil {


### PR DESCRIPTION
right now we search the $PWD for the client binaries to calculate checksum;  this allows us to ignore an error if the client files are missing