### PR TITLE
abstract network protocol from client/server

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/faiface/pixel/text"
 	"github.com/mmogo/mmo/client/assets"
 	"github.com/mmogo/mmo/shared"
-	"github.com/xtaci/kcp-go"
 	"github.com/xtaci/smux"
 	"golang.org/x/image/colornames"
 	"golang.org/x/image/font/basicfont"
@@ -60,20 +59,17 @@ type GameWorld struct {
 func main() {
 	addr := flag.String("addr", "localhost:8080", "address of server")
 	id := flag.String("id", "", "playerid to use")
+	protocol := flag.String("protocol", "kcp", fmt.Sprintf("network protocol to use. available %s | %s | %s", shared.ProtocolUDP, shared.ProtocolTCP, shared.ProtocolKCP))
 	flag.Parse()
 	if *id == "" {
 		log.Fatal("id must be provided")
 	}
-	Main(*addr, *id)
+	pixelgl.Run(Run(*protocol, *addr, *id))
 }
 
-func Main(addr, id string) {
-	pixelgl.Run(Run(addr, id))
-}
-
-func Run(addr, id string) func() {
+func Run(protocol, addr, id string) func() {
 	return func() {
-		if err := run(addr, id); err != nil {
+		if err := run(protocol, addr, id); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -87,11 +83,9 @@ func NewGame() *GameWorld {
 	return g
 }
 
-func run(addr, id string) error {
-
+func run(protocol, addr, id string) error {
 	log.Printf("connecting to %s", addr)
-
-	conn, err := kcp.Dial(addr)
+	conn, err := shared.Dial(protocol, addr)
 	if err != nil {
 		return err
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -59,7 +59,7 @@ type GameWorld struct {
 func main() {
 	addr := flag.String("addr", "localhost:8080", "address of server")
 	id := flag.String("id", "", "playerid to use")
-	protocol := flag.String("protocol", "kcp", fmt.Sprintf("network protocol to use. available %s | %s | %s", shared.ProtocolUDP, shared.ProtocolTCP, shared.ProtocolKCP))
+	protocol := flag.String("protocol", "udp", fmt.Sprintf("network protocol to use. available %s | %s", shared.ProtocolTCP, shared.ProtocolUDP))
 	flag.Parse()
 	if *id == "" {
 		log.Fatal("id must be provided")

--- a/patcher/main.go
+++ b/patcher/main.go
@@ -1,28 +1,28 @@
 package main
 
 import (
+	"crypto/md5"
 	"flag"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 
-	"crypto/md5"
-	"fmt"
 	"github.com/layer-x/layerx-commons/lxhttpclient"
 	"github.com/pborman/uuid"
-	"net/http"
-	"net/url"
 )
 
 var addr = flag.String("addr", "localhost:8080", "http service address")
 var playerID = flag.String("id", "", "player id to use")
 var confFile = flag.String("conf", "login.txt", "login config file")
-var protocol = flag.String("protocol", "kcp", fmt.Sprintf("network protocol to use."))
+var protocol = flag.String("protocol", "udp", fmt.Sprintf("network protocol to use."))
 
 func main() {
 	flag.Parse()

--- a/patcher/main.go
+++ b/patcher/main.go
@@ -22,6 +22,7 @@ import (
 var addr = flag.String("addr", "localhost:8080", "http service address")
 var playerID = flag.String("id", "", "player id to use")
 var confFile = flag.String("conf", "login.txt", "login config file")
+var protocol = flag.String("protocol", "kcp", fmt.Sprintf("network protocol to use."))
 
 func main() {
 	flag.Parse()
@@ -92,7 +93,7 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	cmd := exec.Command(filepath.Join(cwd, clientName), "--addr", *addr, "--id", *playerID)
+	cmd := exec.Command(filepath.Join(cwd, clientName), "--addr", *addr, "--id", *playerID, "--protocol", *protocol)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if err := cmd.Run(); err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -15,8 +15,8 @@ import (
 	"github.com/faiface/pixel"
 	"github.com/ilackarms/pkg/errors"
 	"github.com/mmogo/mmo/shared"
-	"github.com/xtaci/smux"
 	"github.com/soheilhy/cmux"
+	"github.com/xtaci/smux"
 )
 
 func init() {

--- a/server/main.go
+++ b/server/main.go
@@ -32,7 +32,7 @@ const (
 
 func main() {
 	port := flag.Int("port", 8080, "port to serve on")
-	protocol := flag.String("protocol", "kcp", fmt.Sprintf("network protocol to use. available %s | %s | %s", shared.ProtocolUDP, shared.ProtocolTCP, shared.ProtocolKCP))
+	protocol := flag.String("protocol", "udp", fmt.Sprintf("network protocol to use. available %s | %s", shared.ProtocolTCP, shared.ProtocolUDP))
 	flag.Parse()
 	errc := make(chan error)
 	go func() { errc <- serve(*protocol, *port, errc) }()

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -37,10 +37,10 @@ func Listen(protocol, laddr string) (net.Listener, error) {
 		return kcp.Listen(laddr)
 	case ProtocolUDP:
 		return net.Listen("udp", laddr)
-		//case ProtocolTCP:
-		//	return net.Listen("tcp", laddr)
+	case ProtocolTCP:
+		return net.Listen("tcp", laddr)
 	}
-	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s | %s", ProtocolKCP, ProtocolUDP, ProtocolTCP)
+	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s | %s ", ProtocolKCP, ProtocolUDP, ProtocolTCP)
 }
 
 func GetMessage(r io.Reader) (*Message, error) {

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -13,25 +13,38 @@ import (
 	"github.com/xtaci/kcp-go"
 )
 
-//func NewWebsocketListener(laddr string) (net.Listener, error) {
-//	return websocket.BinaryFrame
-//}
+const (
+	ProtocolKCP = "kcp"
+	ProtocolUDP = "udp"
+	ProtocolTCP = "tcp"
+)
 
-func ListenUDP(laddr string) (net.Listener, error) {
-	return net.Listen("udp", laddr)
+func Dial(protocol, raddr string) (net.Conn, error) {
+	switch protocol {
+	case ProtocolKCP:
+		return kcp.Dial(raddr)
+	case ProtocolUDP:
+		return net.Dial("udp", raddr)
+	case ProtocolTCP:
+		return net.Dial("tcp", raddr)
+	}
+	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s | %s", ProtocolKCP, ProtocolUDP, ProtocolTCP)
 }
 
-func ListenTCP(laddr string) (net.Listener, error) {
-	return net.Listen("tcp", laddr)
+func Listen(protocol, laddr string) (net.Listener, error) {
+	switch protocol {
+	case ProtocolKCP:
+		return kcp.Listen(laddr)
+	case ProtocolUDP:
+		return net.Listen("udp", laddr)
+		//case ProtocolTCP:
+		//	return net.Listen("tcp", laddr)
+	}
+	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s | %s", ProtocolKCP, ProtocolUDP, ProtocolTCP)
 }
 
-func ListenKCP(laddr string) (net.Listener, error) {
-	return kcp.Listen(laddr)
-}
-
-func GetMessage(conn net.Conn) (*Message, error) {
-	conn.SetDeadline(time.Now().Add(time.Second * 3))
-	raw, err := read(conn)
+func GetMessage(r io.Reader) (*Message, error) {
+	raw, err := read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -52,15 +65,14 @@ func SendMessage(msg *Message, conn net.Conn) error {
 	return SendRaw(data, conn)
 }
 
-func SendRaw(data []byte, conn net.Conn) error {
-	conn.SetDeadline(time.Now().Add(time.Second * 3))
+func SendRaw(data []byte, w io.Writer) error {
 	size := len(data)
 	if size > math.MaxUint16 {
 		return fmt.Errorf("message size too large: %v", size)
 	}
 	sizeInBytes := make([]byte, 2)
 	binary.BigEndian.PutUint16(sizeInBytes, uint16(size))
-	_, err := conn.Write(append(sizeInBytes, data...))
+	_, err := w.Write(append(sizeInBytes, data...))
 	return err
 }
 

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -14,33 +14,28 @@ import (
 )
 
 const (
-	ProtocolKCP = "kcp"
 	ProtocolUDP = "udp"
 	ProtocolTCP = "tcp"
 )
 
 func Dial(protocol, raddr string) (net.Conn, error) {
 	switch protocol {
-	case ProtocolKCP:
-		return kcp.Dial(raddr)
 	case ProtocolUDP:
-		return net.Dial("udp", raddr)
+		return kcp.Dial(raddr)
 	case ProtocolTCP:
 		return net.Dial("tcp", raddr)
 	}
-	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s | %s", ProtocolKCP, ProtocolUDP, ProtocolTCP)
+	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s", ProtocolUDP, ProtocolTCP)
 }
 
 func Listen(protocol, laddr string) (net.Listener, error) {
 	switch protocol {
-	case ProtocolKCP:
-		return kcp.Listen(laddr)
 	case ProtocolUDP:
-		return net.Listen("udp", laddr)
+		return kcp.Listen(laddr)
 	case ProtocolTCP:
 		return net.Listen("tcp", laddr)
 	}
-	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s | %s ", ProtocolKCP, ProtocolUDP, ProtocolTCP)
+	return nil, fmt.Errorf("invalid protcol %s. select from available: %s | %s ", ProtocolUDP, ProtocolTCP)
 }
 
 func GetMessage(r io.Reader) (*Message, error) {


### PR DESCRIPTION
client and server should simply specify `--protocol <type>` and be configured to communicate over that protocol. client and serve should match. possibly we should add an http endpoint to the server so the client can check the server protocol type and return a useful error to the user (other than Connection Refused)