### PR TITLE
wrap connection with an smux session

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mmogo/mmo/client/assets"
 	"github.com/mmogo/mmo/shared"
 	"github.com/xtaci/kcp-go"
+	"github.com/xtaci/smux"
 	"golang.org/x/image/colornames"
 	"golang.org/x/image/font/basicfont"
 )
@@ -94,6 +95,16 @@ func run(addr, id string) error {
 	if err != nil {
 		return err
 	}
+	session, err := smux.Client(conn, nil)
+	if err != nil {
+		return err
+	}
+	stream, err := session.OpenStream()
+	if err != nil {
+		return err
+	}
+	conn = stream
+
 	connectionRequest := &shared.ConnectRequest{
 		ID: id,
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -95,7 +95,7 @@ func run(addr, id string) error {
 	if err != nil {
 		return err
 	}
-	session, err := smux.Client(conn, nil)
+	session, err := smux.Client(conn, smux.DefaultConfig())
 	if err != nil {
 		return err
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -119,7 +119,7 @@ func serve(port int, errc chan error) error {
 }
 
 func handleConnection(conn net.Conn) error {
-	session, err := smux.Server(conn, nil)
+	session, err := smux.Server(conn, smux.DefaultConfig())
 	if err != nil {
 		return err
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ilackarms/pkg/errors"
 	"github.com/mmogo/mmo/shared"
 	"github.com/xtaci/kcp-go"
+	"github.com/xtaci/smux"
 )
 
 func init() {
@@ -118,6 +119,18 @@ func serve(port int, errc chan error) error {
 }
 
 func handleConnection(conn net.Conn) error {
+	session, err := smux.Server(conn, nil)
+	if err != nil {
+		return err
+	}
+
+	stream, err := session.AcceptStream()
+	if err != nil {
+		return err
+	}
+
+	conn = stream
+
 	// read message
 	msg, err := shared.GetMessage(conn)
 	if err != nil {


### PR DESCRIPTION
this wraps the underlying connection with an [smux](https://github.com/xtaci/smux) session handler on both sides to handle things like broken pipe, packet ordering, etc.

there is a noticeable improvement in client jitter with this change